### PR TITLE
Fix put_fluid_stress_on_shell dof_map

### DIFF
--- a/include/mm_fill_solid.h
+++ b/include/mm_fill_solid.h
@@ -127,21 +127,21 @@ PROTO((int ,			/* id - local element node number for the
 				 * boundaries)                               */
        double ));		/* scale - term scaling                      */
 
-EXTERN void put_fluid_stress_on_shell /* mm_fill_shell.c                    */
-PROTO((int ,			/* id - local element node number for the 
-				 * current node whose residual contribution
-				 * is being sought                           */
-       int ,                    /* Local shell element node num associated   */
-                                /* with id */
-       int ,			/* I - Global node number                    */
-       int ,			/* ielem_dim - physical dimension of element,
-				 * ie., 1, 2, 3                              */
-       double [],		/* resid_vector - Residual vector NO DUH!    */
-       int [],			/* local_node_list_fs - MDE list to keep track
-				 * of nodes at which liquid contributions have
-				 * been transfered to solid (fluid-solid 
-				 * boundaries)                               */
-       double ));		/* scale - term scaling                      */
+EXTERN
+void put_fluid_stress_on_shell(int id, /* local bulk element node number for the
+				   * current node whose residual contribution
+				   * is being sought                        */
+			  int id_shell_curv, /* local shell element node number corresponding to id */
+			  int id_shell_tens, /* local shell element node number corresponding to id */
+			  int I, /* Global node number                      */
+			  int ielem_dim, /* physical dimension of the elem  */
+			  double resid_vector[], /* Residual vector         */
+			  int local_node_list_fs[], /* MDE list to keep track
+						     * of nodes at which
+						     * bulk contributions 
+						     * have been transfered
+						     * to shell  */
+			  double scale); /* Scale factor, nondimension       */
 	   
 EXTERN void  put_shear_stress_on_shell
 PROTO((int ,		/* local element node number for the 

--- a/src/mm_fill_em.c
+++ b/src/mm_fill_em.c
@@ -20,7 +20,9 @@
 #include <stdio.h>
 #include <math.h>
 #include <complex.h>
-
+#ifdef I
+#undef I
+#endif
 /* GOMA include files */
 #define GOMA_MM_FILL_EM_C
 #include "std.h"

--- a/src/mm_fill_shell.c
+++ b/src/mm_fill_shell.c
@@ -4223,7 +4223,8 @@ void
 put_fluid_stress_on_shell(int id, /* local bulk element node number for the
 				   * current node whose residual contribution
 				   * is being sought                        */
-			  int id_shell, /* local shell element node number corresponding to id */
+			  int id_shell_curv, /* local shell element node number corresponding to id */
+			  int id_shell_tens, /* local shell element node number corresponding to id */
 			  int I, /* Global node number                      */
 			  int ielem_dim, /* physical dimension of the elem  */
 			  double resid_vector[], /* Residual vector         */
@@ -4264,7 +4265,6 @@ put_fluid_stress_on_shell(int id, /* local bulk element node number for the
    * variable at every surface node
    */
   id_dofmom1 = id;
-  id_dofshell = id_shell;  /* This is the imperfect assumption */
 
 
   /*
@@ -4298,7 +4298,7 @@ put_fluid_stress_on_shell(int id, /* local bulk element node number for the
       ieqn_mom2   = R_MOMENTUM2;
       id_dofmom1 = id;
       id_dofmom2 = id;
-      id_dofshell = id_shell;
+      id_dofshell = id_shell_curv;
       lec->R[LEC_R_INDEX(upd->ep[ieqn_shell],id_dofshell)] +=
         scale * (fv->snormal[0] * lec->R[LEC_R_INDEX(upd->ep[ieqn_mom1],id_dofmom1)] +
                  fv->snormal[1] * lec->R[LEC_R_INDEX(upd->ep[ieqn_mom2],id_dofmom2)]);
@@ -4309,7 +4309,7 @@ put_fluid_stress_on_shell(int id, /* local bulk element node number for the
       ieqn_mom2   = R_MOMENTUM2;
       id_dofmom1 = id;
       id_dofmom2 = id;
-      id_dofshell = id_shell;
+      id_dofshell = id_shell_tens;
       lec->R[LEC_R_INDEX(upd->ep[ieqn_shell],id_dofshell)] +=
         scale * (fv->stangent[0][0] * lec->R[LEC_R_INDEX(upd->ep[ieqn_mom1],id_dofmom1)] +
                  fv->stangent[0][1] * lec->R[LEC_R_INDEX(upd->ep[ieqn_mom2],id_dofmom2)]);
@@ -4332,7 +4332,7 @@ put_fluid_stress_on_shell(int id, /* local bulk element node number for the
 	  peqn_mom1 = upd->ep[ieqn_mom1];
 	  id_dofmom2 = id;
 	  peqn_mom2 = upd->ep[ieqn_mom2];
-	  id_dofshell = id_shell;
+	  id_dofshell = id_shell_curv;
 
 
 	  /* Add contributions due to all nodal sensitivities in shell element */
@@ -4404,7 +4404,7 @@ put_fluid_stress_on_shell(int id, /* local bulk element node number for the
 	  peqn_mom1 = upd->ep[ieqn_mom1];
 	  id_dofmom2 = id;
 	  peqn_mom2 = upd->ep[ieqn_mom2];
-	  id_dofshell = id_shell;
+	  id_dofshell = id_shell_tens;
 
 
 	  /* Add contributions due to all nodal sensitivities in shell element */


### PR DESCRIPTION
I think this fixes the issue, we will still need to rebaseline because apparently this has always been a odd bug

We don't need to setup shop because gnn_list has the variables and we use the corresponding gun_list to put into matrix so we have to use gnn_list order